### PR TITLE
More limitations

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,8 @@ with open("config.json", "r") as config_file:
     MIN_PORTS = config["random_ports"]["min"]
     MAX_PORTS = config["random_ports"]["max"]
 
+    MAX_CHALLENGES_PER_TEAM = config["max_challenges_per_team"]
+
     CHALLENGES = config["challenges"]
     DOCKER_HOSTS = config["hosts"]
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -89,7 +89,9 @@ def create_instances(session, challenge_info):
             "environment": container.get("environment", {}),
             "mem_limit": container.get("mem_limit", "512m"),
             "privileged": container.get("privileged", False),
-            "read_only": container.get("read_only", False)
+            "read_only": container.get("read_only", False),
+            "cpu_period": container.get("cpu_period", 100000),
+            "cpu_quota": container.get("cpu_quota", 50000)
         })
 
     current_app.logger.debug("Environment for deployment '%s': %s", deploy_config["network_name"], deploy_config)
@@ -123,7 +125,9 @@ def create_instances(session, challenge_info):
                 detach=True,
                 mem_limit=container["mem_limit"],
                 privileged=container["privileged"],
-                read_only=container["read_only"]
+                read_only=container["read_only"],
+                cpu_period=container["cpu_period"], 
+                cpu_quota=container["cpu_quota"]
             )
             instance.ip_address = find_ip_address(container)
         except ImageNotFound as err:
@@ -135,6 +139,11 @@ def create_instances(session, challenge_info):
 
     return len(challenge_info["containers"])
 
+def get_challenge_count_per_team(team_id):
+    """
+    Returns the number of challenges running for a specific team.
+    """
+    return Instances.query.filter_by(team_id=team_id).distinct(Instances.network_name).count()
 
 def find_unused_port(docker_host):
     """

--- a/config.sample.json
+++ b/config.sample.json
@@ -3,6 +3,7 @@
     "ctfd_url": "https://ctf.heroctf.fr",
     "max_instance_count": 100,
     "max_instance_duration": 100,
+    "max_challenges_per_team": 5,
     "random_ports": {
         "min": 10000,
         "max": 15000
@@ -63,7 +64,9 @@
                         }
                     ],
                     "mem_limit": "1024m",
-                    "read_only": false
+                    "read_only": false,
+                    "cpu_period" : 100000,
+                    "cpu_quota" : 100000
                 }
             ]
         }


### PR DESCRIPTION
* Added key in config.json named "max_challenges_per_team" that let us choose a limit of challenges per team in case ctfd have no limit. To keep the original behavior, set the value to 0.
* Added keys to the containers definitions mapped from the original docker command : "cpu_quota" and "cpu_period".
